### PR TITLE
Block cron from ALL at the beginning

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,6 +14,9 @@ profile_pam_access::allow_rules:
     user: "root"
     origin: "cron crond 127.0.0.1 :0 tty"
 profile_pam_access::deny_first_rules:
+  "ALL deny for cron":
+    user: "ALL"
+    origin: "cron crond"
   "deny all_disabled_usr":
     group: "all_disabled_usr"
     origin: "ALL"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,14 +41,6 @@ class profile_pam_access (
   ### Make sure pam is installed
   ensure_packages( $required_pkgs )
 
-  ### Configure access.conf
-
-  pam_access::entry { 'Default Allow':
-    user       => 'root',
-    origin     => 'LOCAL',
-    permission => '+',
-    position   => 'before',
-  }
 
   pam_access::entry { 'Default Deny':
     user       => 'ALL',
@@ -74,6 +66,12 @@ class profile_pam_access (
       'position'   => 'before',
     }
   )
+  -> pam_access::entry { 'Default Allow':
+    user       => 'root',
+    origin     => 'LOCAL',
+    permission => '+',
+    position   => 'before',
+  }
 
   ### Configure pam
   ensure_resources( 'pam', $pam_config )


### PR DESCRIPTION
Per security recommendation raised during ISL vetting. Currently implemented in Hiera for isl-control.

The goal with this is to prevent anything with LOCAL allowed from accessing cron.