### PR TITLE
bypass nologin for ansible and qualys groups

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,3 +26,14 @@ profile_pam_access::pam_config:
     control: "required"
     module: "pam_access.so"
     position: "before module pam_nologin.so"
+  "profile_pam_access bypass nologin for ansible and qualys":
+    ensure: "present"
+    service: "sshd"
+    type: "account"
+    control: "[success=1 default=ignore]"
+    module: "pam_succeed_if.so"
+    arguments:
+      - "user"
+      - "ingroup"
+      - "ansible:qualys"
+    position: "after module pam_access.so"


### PR DESCRIPTION
In /etc/pam.d/sshd -

account [success=1 default=ignore] pam_succeed_if.so user ingroup ansible:qualys

immediately before the "account required pam_nologin.so" line will allow users in the ansible and qualys groups to bypass the /etc/nologin check.

I successfully tested on dt-testlogin02 
