### PR TITLE
Jlong/ncsacc 1915 bypass nologin for ansible and qualys users

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -43,3 +43,4 @@ profile_pam_access::pam_config:
       - "user"
       - "ingroup"
       - "ansible:qualys"
+      - "quiet_fail"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -30,10 +30,16 @@ profile_pam_access::pam_config:
     ensure: "present"
     service: "sshd"
     type: "account"
-    control: "[success=1 default=ignore]"
+    control: "include"
+    module: "sshd-ansible-qualys"
+    position: "after module pam_access.so"
+  "add sshd-ansible-qualys service":
+    ensure: "present"
+    service: "sshd-ansible-qualys"
+    type: "account"
+    control: "sufficient"
     module: "pam_succeed_if.so"
     arguments:
       - "user"
       - "ingroup"
       - "ansible:qualys"
-    position: "after module pam_access.so"


### PR DESCRIPTION
added sshd-ansible-qualys service with these contents -

account sufficient pam_succeed_if.so user ingroup ansible:qualys quiet_fail


And placed it after module pam_access.so

This allows for a seconds "pam_succeed_if.so module that does not compete with the puppet hostbased module.

Tested on compute and login nodes on delta (both newly booted, and non-booted with old config)